### PR TITLE
fix album cover z-index

### DIFF
--- a/popup/controls.css
+++ b/popup/controls.css
@@ -148,6 +148,8 @@ body {
 
 .ambilight .image {
   width: 100%;
+  position: relative;
+  z-index: 100;
 }
 
 .ambilight .light {


### PR DESCRIPTION
Blurred album image appears to cover original album image so it is also blurred. Simple fix applied.
Before:
![before](https://user-images.githubusercontent.com/18082240/73850236-5f294800-483c-11ea-8b11-504ee64a841f.png)
After:
![after](https://user-images.githubusercontent.com/18082240/73850243-62243880-483c-11ea-96e3-2445ba68642b.png)

